### PR TITLE
switch to using alpine-release + alpine-baselayout-data instead of alpine-base

### DIFF
--- a/.apko.yaml
+++ b/.apko.yaml
@@ -2,5 +2,8 @@ contents:
   repositories:
     - https://dl-cdn.alpinelinux.org/alpine/edge/main
   packages:
-    - alpine-base
-    - busybox-ifupdown
+    - alpine-baselayout-data
+    - alpine-release
+    - apk-tools
+    - busybox
+    - libc-utils


### PR DESCRIPTION
alpine-release package is a new package which contains only the alpine
release data.  this allows us to avoid a lot of the dependencies of
alpine-base, such as openrc, without having to resort to recreating
the release data like the alpine docker image building scripts presently
do.